### PR TITLE
fix(OnKillPlayer/Kill Self): Don't count self death

### DIFF
--- a/Ultimate_Full_Loot_Pvp.lua
+++ b/Ultimate_Full_Loot_Pvp.lua
@@ -1259,6 +1259,8 @@ end
 
 -- -------------------------------------------------------------- main callback
 local function OnKillPlayer(event, killer, victim)
+    if killer == victim then return end
+    
     -- grab the per-zone config
     local mapId = victim:GetMapId()
     local areaId = victim:GetAreaId()


### PR DESCRIPTION
If players die from e.g., fatigue or gravity, OnKillPlayer fires as if they killed themselves, making them drop all their items and trigger MMR drop but spawn no chest, etc.